### PR TITLE
Add applied plan options screen

### DIFF
--- a/client/src/components/App.js
+++ b/client/src/components/App.js
@@ -110,7 +110,7 @@ function App() {
         <Route path="/login">
           <Login />
         </Route>
-        <Route path="/createPlan">
+        <Route path="/createPlan/:planId">
           <StudentCreatePlan />
         </Route>
         <Route path="/viewPlan/:planId">

--- a/client/src/components/create_plan/EditPlan.js
+++ b/client/src/components/create_plan/EditPlan.js
@@ -196,7 +196,7 @@ function EditPlan(props) {
             // reqCourse contain list of core course option
             // Student must take at least one course from reqCourse list
             for (let j = 0; j < props.reqCourse.length; j++) {
-                if (props.courses[i].courseCode == props.reqCourse[j]) {
+                if (props.courses[i].courseCode === props.reqCourse[j]) {
                     hasReqCourse = true;
                     break;
                 }

--- a/client/src/components/create_plan/EditPlan.js
+++ b/client/src/components/create_plan/EditPlan.js
@@ -188,6 +188,28 @@ function EditPlan(props) {
       setWarning(`Plan name must be between ${NAME_MIN} and ${NAME_MAX} characters.`);
       return false;
     }
+    // check that at least 1 core course option is picked
+    // if reqCourse is empty skip this check
+    if (props.reqCourse && props.reqCourse.length > 0) {
+        let hasReqCourse = false;
+        for (let i = 0; i < props.courses.length; i++) {
+            // reqCourse contain list of core course option
+            // Student must take at least one course from reqCourse list
+            for (let j = 0; j < props.reqCourse.length; j++) {
+                if (props.courses[i].courseCode == props.reqCourse[j]) {
+                    hasReqCourse = true;
+                    break;
+                }
+            }
+            if (hasReqCourse) {
+                break;
+            }
+        }
+        if (hasReqCourse === false) {
+            setWarning(`Plan must contain at least 1 course from the following list: ${props.reqCourse.join(", ")}.`);
+            return false;
+        }
+    }
     // check that the minimum amount of credits are selected
     const credits = loadCredits();
     if (credits < CREDITS_MIN) {

--- a/client/src/components/create_plan/EditPlanTable.js
+++ b/client/src/components/create_plan/EditPlanTable.js
@@ -108,5 +108,5 @@ export default EditPlanTable;
 EditPlanTable.propTypes = {
   onRemoveCourse: PropTypes.func,
   courseId: PropTypes.number,
-  courses: PropTypes.object
+  courses: PropTypes.array
 };

--- a/client/src/components/create_plan/StudentCreatePlan.js
+++ b/client/src/components/create_plan/StudentCreatePlan.js
@@ -5,7 +5,7 @@ import EditPlan from "./EditPlan";
 import CourseSearch from "./CourseSearch";
 import Navbar from "../navbar/Navbar";
 import PageSpinner from "../general/PageSpinner";
-import {useParams} from "react-router-dom";
+import {useLocation, useParams} from "react-router-dom";
 import PageInternalError from "../general/PageInternalError";
 import PageNotFound from "../general/PageNotFound";
 import {css, jsx} from "@emotion/core";
@@ -22,7 +22,8 @@ export default function StudentCreatePlan() {
   const [warning, setWarning] = useState("");
   const [edit, setEdit] = useState(0);
   const {planId} = useParams();
-
+  const location = useLocation();
+  
   const style = css`
     & {
       display: grid;
@@ -85,13 +86,62 @@ export default function StudentCreatePlan() {
       }
     }
 
+    async function searchCourse(planId) {
+        setPlanLoading(true);
+        // List of prefilled courses
+        let courses = [["CS 331", "CS 434", "MTH 254", "MTH 341", "ST 421", "CS 475"], // Artificial Intelligence
+                       ["CS 434", "CS 440", "CS 453", "BI 212", "BI 213"], // ? Bioinformatics
+                       ["CS 440"], // Business & Entrepreneurship
+                       ["CS 321", "CS 370", "CS 373", "CS 427", "CS 478"], // Cybersecurity
+                       ["CS 434", "CS 440", "CS 475", "MTH 254", "MTH 341", "ST 421", "CS 453"], // ? Data Science
+                       ["CS 468", "CS 453", "CS 492", "PSY 340"], // ? Human Computer Interaction
+                       ["CS 331", "CS 434", "ROB 421", "ROB 456", "MTH 254", "MTH 341", "PH 211", "PH 221"], // Robot Intelligence
+                       ["CS 450"], // Simulation & Game Programming
+                       ["CS 370", "CS 458", "CS 492", "CS 493"]]; // ? Web & Mobile Application Development
+        
+        // If this is a prefill plan, add prefilled courses
+        if (planId >= 1 && planId <=  9) {  // planId index at 1 to set null planId as custom plan
+            let i;
+            let prefillClasses = [];
+            for (i = 0; i < courses[planId - 1].length; i++) {
+                try {
+                    const url = `/api/course/search/${courses[planId - 1][i]}/*`;
+                    const results = await fetch(url);
+                    
+                    if (results.ok) {
+                        let obj = await results.json();
+                        if (obj && obj.courses && obj.courses.length > 0) {
+                            let c;
+                            for (c of obj.courses) {
+                                if (c.courseCode === courses[planId - 1][i]) {
+                                    prefillClasses.push(c);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+                catch (err) {
+                    console.log("Failed to add required courses. Err: " + err);
+                }
+            }
+            setCourses(prefillClasses);
+        }
+        setPlanLoading(false);
+    }
     // only fetch a plan if we are on the edit plan page
-    if (planId) {
-      setEdit(parseInt(planId));
-      fetchPlan(planId);
+    if (location.pathname.substring(0, 9) === "/editPlan" && planId) {
+        setEdit(parseInt(planId));
+        fetchPlan(planId);
+    }
+    // if we're on create plan page check if plan is prefilled plan and add requisite courses
+    else if (location.pathname.substring(0, 11) === "/createPlan") {
+        if (planId) {
+            searchCourse(parseInt(planId));
+        }
     }
 
-  }, [planId]);
+  }, [planId, location]);
 
   // track the state of multiple page components loading and
   // display a spinner if any part of the page is still loading

--- a/client/src/components/create_plan/StudentCreatePlan.js
+++ b/client/src/components/create_plan/StudentCreatePlan.js
@@ -20,6 +20,7 @@ export default function StudentCreatePlan() {
   const [planName, setPlanName] = useState("");
   const [courses, setCourses] = useState([]);
   const [warning, setWarning] = useState("");
+  const [reqCourseOption, setReqCourseOption] = useState([]);
   const [edit, setEdit] = useState(0);
   const {planId} = useParams();
   const location = useLocation();
@@ -89,23 +90,25 @@ export default function StudentCreatePlan() {
     async function searchCourse(planId) {
         setPlanLoading(true);
         // List of prefilled courses
-        let courses = [["CS 331", "CS 434", "MTH 254", "MTH 341", "ST 421", "CS 475"], // Artificial Intelligence
-                       ["CS 434", "CS 440", "CS 453", "BI 212", "BI 213"], // ? Bioinformatics
+        let appCourses = [["CS 331", "CS 434", "MTH 254", "MTH 341", "ST 421", "CS 475"], // Artificial Intelligence
+                       ["CS 434", "CS 440", "BI 212", "BI 213"], // ? Bioinformatics
                        ["CS 440"], // Business & Entrepreneurship
                        ["CS 321", "CS 370", "CS 373", "CS 427", "CS 478"], // Cybersecurity
-                       ["CS 434", "CS 440", "CS 475", "MTH 254", "MTH 341", "ST 421", "CS 453"], // ? Data Science
-                       ["CS 468", "CS 453", "CS 492", "PSY 340"], // ? Human Computer Interaction
+                       ["CS 434", "CS 440", "CS 475", "MTH 254", "MTH 341", "ST 421", ], // ? Data Science
+                       ["CS 468", "CS 453", "CS 492", "PSY 340"], // Human Computer Interaction
                        ["CS 331", "CS 434", "ROB 421", "ROB 456", "MTH 254", "MTH 341", "PH 211", "PH 221"], // Robot Intelligence
                        ["CS 450"], // Simulation & Game Programming
-                       ["CS 370", "CS 458", "CS 492", "CS 493"]]; // ? Web & Mobile Application Development
-        
+                       ["CS 370", "CS 492", "CS 493"]]; // ? Web & Mobile Application Development
+        // Some prefilled course requirements are options between two courses. This is a list of those options for each
+        // applied plan
+        let reqCourses = [[], ["CS 453", "CS 458"], [], [], ["CS 453", "CS 458"], [], [], [], ["CS 458", "CS 468"]]
         // If this is a prefill plan, add prefilled courses
         if (planId >= 1 && planId <=  9) {  // planId index at 1 to set null planId as custom plan
             let i;
             let prefillClasses = [];
-            for (i = 0; i < courses[planId - 1].length; i++) {
+            for (i = 0; i < appCourses[planId - 1].length; i++) {
                 try {
-                    const url = `/api/course/search/${courses[planId - 1][i]}/*`;
+                    const url = `/api/course/search/${appCourses[planId - 1][i]}/*`;
                     const results = await fetch(url);
                     
                     if (results.ok) {
@@ -113,7 +116,7 @@ export default function StudentCreatePlan() {
                         if (obj && obj.courses && obj.courses.length > 0) {
                             let c;
                             for (c of obj.courses) {
-                                if (c.courseCode === courses[planId - 1][i]) {
+                                if (c.courseCode === appCourses[planId - 1][i]) {
                                     prefillClasses.push(c);
                                     break;
                                 }
@@ -126,6 +129,7 @@ export default function StudentCreatePlan() {
                 }
             }
             setCourses(prefillClasses);
+            setReqCourseOption(reqCourses[planId - 1]);
         }
         setPlanLoading(false);
     }
@@ -214,7 +218,7 @@ export default function StudentCreatePlan() {
       <div className="student-create-plan" css={style}>
         <PageSpinner loading={loading} />
         <Navbar currentPlan={0} />
-        <EditPlan courses={courses} edit={edit} planName={planName} onLoading={load => setSubmitLoading(load)}
+        <EditPlan courses={courses} reqCourse={reqCourseOption} edit={edit} planName={planName} onLoading={load => setSubmitLoading(load)}
           onChangePlanName={e => setPlanName(e)} onRemoveCourse={e => handleRemoveCourse(e)}  />
         <CourseSearch warning={warning} onAddCourse={e => handleAddCourse(e)}
           onNewWarning={e => setWarning(e)}/>

--- a/client/src/components/student_home/PlanSelect.js
+++ b/client/src/components/student_home/PlanSelect.js
@@ -9,8 +9,8 @@ function PlanSelect(props) {
         top: 0px;
         left: 0px;
         background-color: rgba(0,0,0,0.6);
-        width: 100vw;
-        height: 100vh;
+        width: 100%;
+        height: 100%;
         z-index: 10;
         visibility: ${props.hidden ? "hidden" : "visible"};
         display: flex;
@@ -19,8 +19,9 @@ function PlanSelect(props) {
         align-items: center;
 
         .option {
-            width: 40vw;
-            height: 5vh;
+            width: 40%;
+            height: 5%;
+            max-height: 40px;
             border-radius: 10px;
             background-color: white;
             border-style: hidden;
@@ -39,13 +40,23 @@ function PlanSelect(props) {
 
         .header {
             color: white;
-            width: 40vw;
+            width: 40%;
             text-align: center;
         }
 
         .header > span {
             font-size: 20px;
             font-weight: bold;
+        }
+
+        @media screen and (max-width: 600px) {
+            .option {
+                width: 70%;
+            }
+
+            .header {
+                width: 70%;
+            }
         }
     `;
 

--- a/client/src/components/student_home/PlanSelect.js
+++ b/client/src/components/student_home/PlanSelect.js
@@ -1,0 +1,95 @@
+/** @jsx jsx */
+
+import {css, jsx} from "@emotion/core";
+import { withRouter } from 'react-router'
+
+function PlanSelect(props) {
+    const styles = css`
+        position: fixed;
+        top: 0px;
+        left: 0px;
+        background-color: rgba(0,0,0,0.6);
+        width: 100vw;
+        height: 100vh;
+        z-index: 10;
+        visibility: ${props.hidden ? "hidden" : "visible"};
+        display: flex;
+        flex-direction: column;
+        justify-content: space-around;
+        align-items: center;
+
+        .option {
+            width: 40vw;
+            height: 5vh;
+            border-radius: 10px;
+            background-color: white;
+            border-style: hidden;
+            font-size: 16px;
+            font-style: normal;
+        }
+
+        .close {
+            color: white;
+            opacity: 1;
+        }
+
+        .close > span {
+            font-size: 24px;
+        }
+
+        .header {
+            color: white;
+            width: 40vw;
+            text-align: center;
+        }
+
+        .header > span {
+            font-size: 20px;
+            font-weight: bold;
+        }
+    `;
+
+    return (
+        <div css={styles}>
+            <div className="header">
+                <span>Select an Applied Option</span>
+                <button type="button" className="close" aria-label="Close" onClick={props.hidePlan}>
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            
+            <button className="option" onClick={() => props.history.push("/createPlan")}>
+                Artificial Intelligence
+            </button>
+            <button className="option">
+                Bioinformatics
+            </button>
+            <button className="option">
+                Business {"&"} Entrepreneurship
+            </button>
+            <button className="option">
+                Cybersecurity
+            </button>
+            <button className="option">
+                Data Science
+            </button>
+            <button className="option">
+                Human Computer Interaction
+            </button>
+            <button className="option">
+                Robot Intelligence
+            </button>
+            <button className="option">
+                Simulation {"&"} Game Programming
+            </button>
+            <button className="option">
+                Web {"&"} Mobile Application Development
+            </button>
+            <button className="option">
+                Custom Plan
+            </button>
+        </div>
+    );
+}
+
+export default withRouter(PlanSelect);

--- a/client/src/components/student_home/PlanSelect.js
+++ b/client/src/components/student_home/PlanSelect.js
@@ -58,34 +58,34 @@ function PlanSelect(props) {
                 </button>
             </div>
             
-            <button className="option" onClick={() => props.history.push("/createPlan")}>
+            <button className="option" onClick={() => props.history.push("/createPlan/1")}>
                 Artificial Intelligence
             </button>
-            <button className="option">
+            <button className="option" onClick={() => props.history.push("/createPlan/2")}>
                 Bioinformatics
             </button>
-            <button className="option">
+            <button className="option" onClick={() => props.history.push("/createPlan/3")}>
                 Business {"&"} Entrepreneurship
             </button>
-            <button className="option">
+            <button className="option" onClick={() => props.history.push("/createPlan/4")}>
                 Cybersecurity
             </button>
-            <button className="option">
+            <button className="option" onClick={() => props.history.push("/createPlan/5")}>
                 Data Science
             </button>
-            <button className="option">
+            <button className="option" onClick={() => props.history.push("/createPlan/6")}>
                 Human Computer Interaction
             </button>
-            <button className="option">
+            <button className="option" onClick={() => props.history.push("/createPlan/7")}>
                 Robot Intelligence
             </button>
-            <button className="option">
+            <button className="option" onClick={() => props.history.push("/createPlan/8")}>
                 Simulation {"&"} Game Programming
             </button>
-            <button className="option">
+            <button className="option" onClick={() => props.history.push("/createPlan/9")}>
                 Web {"&"} Mobile Application Development
             </button>
-            <button className="option">
+            <button className="option" onClick={() => props.history.push("/createPlan/0")}>
                 Custom Plan
             </button>
         </div>

--- a/client/src/components/student_home/StudentHome.js
+++ b/client/src/components/student_home/StudentHome.js
@@ -286,7 +286,7 @@ function StudentHome() {
               </table>
               : <div className="empty-plan-container">
                 <h3 className="empty-plan-title">You haven&#39;t created any plans.</h3>
-                <a href="createPlan" title="Create a plan" className="empty-plan-create-button">Create a plan</a>
+                <button className="empty-plan-create-button" onClick={() => setShowPlans(true)}>Create a plan</button>
               </div>
             }
             {/* <a href="createPlan" title="Create a plan" className="new-plan-button"></a> */}

--- a/client/src/components/student_home/StudentHome.js
+++ b/client/src/components/student_home/StudentHome.js
@@ -9,6 +9,7 @@ import StatusCue from "./StatusCue";
 import PageSpinner from "../general/PageSpinner";
 import PageInternalError from "../general/PageInternalError";
 import {statusText} from "../../utils/renderStatus";
+import PlanSelect from "./PlanSelect";
 
 import {css, jsx} from "@emotion/core";
 
@@ -18,6 +19,7 @@ function StudentHome() {
   const [pageError, setPageError] = useState(0);
   const [plans, setPlans] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [showPlans, setShowPlans] = useState(false);
 
   const style = css`
 
@@ -287,8 +289,9 @@ function StudentHome() {
                 <a href="createPlan" title="Create a plan" className="empty-plan-create-button">Create a plan</a>
               </div>
             }
-            <a href="createPlan" title="Create a plan" className="new-plan-button"></a>
-
+            {/* <a href="createPlan" title="Create a plan" className="new-plan-button"></a> */}
+            <button className="new-plan-button" onClick={() => setShowPlans(true)}></button>
+            <PlanSelect hidden={!showPlans} hidePlan={() => setShowPlans(false)}/>
           </div>
         </div>
 


### PR DESCRIPTION
Add a screen for students to select an applied plan option before entering edit plan page.
Add responsive css to the screen to make it look nice on mobile.
Changed functionality of edit plan page to prefill with appropriate core classes for each applied plan options